### PR TITLE
Rotate

### DIFF
--- a/modules/display.py
+++ b/modules/display.py
@@ -27,6 +27,8 @@ class emulator(Thread):
     self.daemon = True
     self.width = width
     self.height = height
+    self.xoffset = 0
+    self.yoffset = 0
     self.file = file
     self.start()
 
@@ -90,6 +92,8 @@ class display:
     self.pheight = self.height
 
     if self.rotated:
+      # Calculate offset for X, must be even dividable with 16
+      self.xoffset = 16 - (self.height % 16)
       self.width = self.pheight
       self.height = self.pwidth
 
@@ -212,6 +216,8 @@ class display:
       '-pointsize',
       '32',
       'label:%s' % message,
+      '-extent',
+      '%dx%d+%d+%d' % (self.width + self.xoffset, self.height + self.yoffset, self.xoffset, self.yoffset),
       '-depth',
       '8',
       '%s:-' % self.format
@@ -234,7 +240,7 @@ class display:
       '-gravity',
       'center',
       '-extent',
-      '%dx%d' % (self.width, self.height),
+      '%dx%d+%d+%d' % (self.width + self.xoffset, self.height + self.yoffset, self.xoffset, self.yoffset),
       '-depth',
       '8',
       '%s:-' % self.format

--- a/modules/display.py
+++ b/modules/display.py
@@ -27,8 +27,6 @@ class emulator(Thread):
     self.daemon = True
     self.width = width
     self.height = height
-    self.xoffset = 0
-    self.yoffset = 0
     self.file = file
     self.start()
 
@@ -61,6 +59,8 @@ class display:
     self.emulate = use_emulator
     self.emulator = None
     self.rotated = self.isRotated()
+    self.xoffset = 0
+    self.yoffset = 0
     if self.emulate:
       logging.info('Using framebuffer emulation')
 
@@ -126,7 +126,7 @@ class display:
               '-depth',
               '8',
               '-size',
-              '%dx%d' % (self.width, self.height),
+              '%dx%d' % (self.width+self.xoffset, self.height+self.yoffset),
               '%s:-' % (self.format),
               'jpg:-'
       ]

--- a/modules/display.py
+++ b/modules/display.py
@@ -256,7 +256,7 @@ class display:
             subprocess.call(['/opt/vc/bin/tvservice', '-e', self.params], stderr=self.void, stdout=self.void)
           time.sleep(1)
           subprocess.call(['/bin/fbset', '-fb', self.getDevice(), '-depth', '8'], stderr=self.void)
-          subprocess.call(['/bin/fbset', '-fb', self.getDevice(), '-depth', str(self.depth), '-xres', str(self.pwidth), '-yres', str(self.pheight), '-vxres', str(self.pwidth), '-vyres', str(self.pheight)], stderr=self.void)
+          subprocess.call(['/bin/fbset', '-fb', self.getDevice(), '-depth', str(self.depth), '-xres', str(self.width), '-yres', str(self.height), '-vxres', str(self.width), '-vyres', str(self.height)], stderr=self.void)
         else:
           subprocess.call(['/usr/bin/vcgencmd', 'display_power', '1'], stderr=self.void)
     else:


### PR DESCRIPTION
Should now properly detect a rotated display (display_rotate=1 or 3 in /boot/config) and render appropiately