### PR TITLE
Allow user control of how to deal with aspect ratio

### DIFF
--- a/modules/helper.py
+++ b/modules/helper.py
@@ -58,7 +58,7 @@ class helper:
 		return None
 
 	@staticmethod
-	def makeFullframe(filename, displayWidth, displayHeight):
+	def makeFullframe(filename, displayWidth, displayHeight, zoomOnly=True):
 		name, ext = os.path.splitext(filename)
 		filename_temp = "%s-frame%s" % (name, ext)
 
@@ -115,42 +115,56 @@ class helper:
 		cmd = None
 		try:
 			# Time to process
-			cmd = [
-				'convert',
-				filename + '[0]',
-				'-resize',
-				'%sx%s^' % (displayWidth, displayHeight),
-				'-gravity',
-				'center',
-				'-crop',
-				'%sx%s+0+0' % (displayWidth, displayHeight),
-				'+repage',
-				'-blur',
-				'0x12',
-				'-brightness-contrast',
-				'-20x0',
-				'(',
-				filename + '[0]',
-				'-bordercolor',
-				'black',
-				'-border',
-				border,
-				'-bordercolor',
-				'black',
-				'-border',
-				spacing,
-				'-resize',
-				'%sx%s' % (displayWidth, displayHeight),
-				'-background',
-				'transparent',
-				'-gravity',
-				'center',
-				'-extent',
-				'%sx%s' % (displayWidth, displayHeight),
-				')',
-				'-composite',
-				filename_temp
-			]
+			if zoomOnly:
+				cmd = [
+					'convert',
+					filename + '[0]',
+					'-resize',
+					'%sx%s^' % (displayWidth, displayHeight),
+					'-gravity',
+					'center',
+					'-crop',
+					'%sx%s+0+0' % (displayWidth, displayHeight),
+					'+repage',
+					filename_temp
+				]
+			else:
+				cmd = [
+					'convert',
+					filename + '[0]',
+					'-resize',
+					'%sx%s^' % (displayWidth, displayHeight),
+					'-gravity',
+					'center',
+					'-crop',
+					'%sx%s+0+0' % (displayWidth, displayHeight),
+					'+repage',
+					'-blur',
+					'0x12',
+					'-brightness-contrast',
+					'-20x0',
+					'(',
+					filename + '[0]',
+					'-bordercolor',
+					'black',
+					'-border',
+					border,
+					'-bordercolor',
+					'black',
+					'-border',
+					spacing,
+					'-resize',
+					'%sx%s' % (displayWidth, displayHeight),
+					'-background',
+					'transparent',
+					'-gravity',
+					'center',
+					'-extent',
+					'%sx%s' % (displayWidth, displayHeight),
+					')',
+					'-composite',
+					filename_temp
+				]
 		except:
 			logging.exception('Error building command line')
 			logging.debug('Filename: ' + repr(filename))

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -64,6 +64,7 @@ class settings:
 			'shutdown-pin' : 26,
 			'display-driver' : 'none',
 			'display-special' : None,
+			'imagesizing' : 'blur',
 		}
 
 	def load(self):

--- a/modules/slideshow.py
+++ b/modules/slideshow.py
@@ -107,7 +107,10 @@ class slideshow:
           self.imageMime = result['mimetype']
           self.imageCurrent = filename
 
-          helper.makeFullframe(filename, self.settings.getUser('width'), self.settings.getUser('height'))
+          if self.settings.getUser('imagesizing') == 'blur':
+            helper.makeFullframe(filename, self.settings.getUser('width'), self.settings.getUser('height'))
+          elif self.settings.getUser('imagesizing') == 'zoom':
+            helper.makeFullframe(filename, self.settings.getUser('width'), self.settings.getUser('height'), zoomOnly=True)
           if self.colormatch.hasSensor():
             if not self.colormatch.adjust(filename):
               logging.warning('Unable to adjust image to colormatch, using original')

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -90,6 +90,14 @@ $("select[name=powersave]").change(function() {
   });
 });
 
+$("select[name=imagesizing]").change(function() {
+  $.ajax({
+    url:"/setting/" + $(this).attr('name') + "/" + encodeURIComponent($(this).val()),
+    type:"PUT"
+  }).done(function(){
+  });
+});
+
 $("select[name=tvservice]").change(function() {
   $.ajax({
     url:"/setting/tvservice/" + encodeURIComponent($(this).val()),

--- a/static/template/main.html
+++ b/static/template/main.html
@@ -63,6 +63,15 @@
 			{{/each}}
 			{{/select}}
 		</select>
+		<br>
+		How to handle images which don't fill the screen
+		<select name="imagesizing">
+			{{#select settings.imagesizing}}
+			<option value="none">Do nothing</option>
+			<option value="blur">Show blurred image</option>
+			<option value="zoom">Zoom to fill</option>
+			{{/select}}
+		</select>
 	</div>
 </div>
 <br>


### PR DESCRIPTION
Some images will not match the screen aspect ratio. This change
will allow the user to choose one of three options:

1. Do nothing (ie, black bars)
2. Show blurred image (fills the black bars with a tweaked copy)
3. Zoom to fit

In all cases, the image is first resized to best fit the display.