### PR TITLE
fixes scaling issues (especially in "ZoomOnly" mode)

### DIFF
--- a/modules/helper.py
+++ b/modules/helper.py
@@ -96,7 +96,6 @@ class helper:
 
 			logging.debug('Size of image is %dx%d, screen is %dx%d. New size is %dx%d', width, height, displayWidth, displayHeight, adjWidth, adjHeight)
 
-			resizeString = '%sx%s'
 			if adjHeight < displayHeight:
 				border = '0x%d' % width_border
 				spacing = '0x%d' % width_spacing
@@ -110,6 +109,7 @@ class helper:
 				resizeString = '^%sx%s'
 				logging.debug('Portrait image, reframing (padding required %dpx)' % padding)
 			else:
+				resizeString = '%sx%s'
 				logging.debug('Image is fullscreen, no reframing needed')
 				return False
 

--- a/modules/helper.py
+++ b/modules/helper.py
@@ -80,41 +80,55 @@ class helper:
 		width_spacing = 3
 		border = None
 		borderSmall = None
+		spacing = None
 
 		# Calculate actual size of image based on display
-		ar = (float)(width) / (float)(height)
-		if width > displayWidth:
-			adjWidth = displayWidth
-			adjHeight = int(float(displayWidth) / ar)
-		else:
-			adjWidth = int(float(displayHeight) * ar)
-			adjHeight = displayHeight
+		oar = (float)(width) / (float)(height)
+		dar = (float)(displayWidth) / (float)(displayHeight)
 
-		logging.debug('Size of image is %dx%d, screen is %dx%d. New size is %dx%d', width, height, displayWidth, displayHeight, adjWidth, adjHeight)
+		if not zoomOnly:
+			if width > displayWidth:
+				adjWidth = displayWidth
+				adjHeight = int(float(displayWidth) / oar)
+			else:
+				adjWidth = int(float(displayHeight) * oar)
+				adjHeight = displayHeight
 
-		resizeString = '%sx%s'
-		if adjHeight < displayHeight:
-			border = '0x%d' % width_border
-			spacing = '0x%d' % width_spacing
-			padding = ((displayHeight - adjHeight) / 2 - width_border)
-			resizeString = '%sx%s^'
-			logging.debug('Landscape image, reframing (padding required %dpx)' % padding)
-		elif adjWidth < displayWidth:
-			border = '%dx0' % width_border
-			spacing = '%dx0' % width_spacing
-			padding = ((displayWidth - adjWidth) / 2 - width_border)
-			resizeString = '^%sx%s'
-			logging.debug('Portrait image, reframing (padding required %dpx)' % padding)
-		else:
-			logging.debug('Image is fullscreen, no reframing needed')
-			return False
+			logging.debug('Size of image is %dx%d, screen is %dx%d. New size is %dx%d', width, height, displayWidth, displayHeight, adjWidth, adjHeight)
 
-		if padding < 20 and not autoChoose:
-			logging.debug('That\'s less than 20px so skip reframing (%dx%d => %dx%d)', width, height, adjWidth, adjHeight)
-			return False
+			resizeString = '%sx%s'
+			if adjHeight < displayHeight:
+				border = '0x%d' % width_border
+				spacing = '0x%d' % width_spacing
+				padding = ((displayHeight - adjHeight) / 2 - width_border)
+				resizeString = '%sx%s^'
+				logging.debug('Landscape image, reframing (padding required %dpx)' % padding)
+			elif adjWidth < displayWidth:
+				border = '%dx0' % width_border
+				spacing = '%dx0' % width_spacing
+				padding = ((displayWidth - adjWidth) / 2 - width_border)
+				resizeString = '^%sx%s'
+				logging.debug('Portrait image, reframing (padding required %dpx)' % padding)
+			else:
+				logging.debug('Image is fullscreen, no reframing needed')
+				return False
 
-		if padding < 60 and autoChoose:
-			zoomOnly = True
+			if padding < 20 and not autoChoose:
+				logging.debug('That\'s less than 20px so skip reframing (%dx%d => %dx%d)', width, height, adjWidth, adjHeight)
+				return False
+
+			if padding < 60 and autoChoose:
+				zoomOnly = True
+
+		if zoomOnly:
+			if oar <= dar:
+				adjWidth = displayWidth
+				adjHeight = int(float(displayWidth) / oar)
+				logging.debug('Size of image is %dx%d, screen is %dx%d. New size is %dx%d  --> cropped to %dx%d', width, height, displayWidth, displayHeight, adjWidth, adjHeight, displayWidth, displayHeight)
+			else:
+				adjWidth = int(float(displayHeight) * oar)
+				adjHeight = displayHeight
+				logging.debug('Size of image is %dx%d, screen is %dx%d. New size is %dx%d --> cropped to %dx%d', width, height, displayWidth, displayHeight, adjWidth, adjHeight, displayWidth, displayHeight)
 
 		cmd = None
 		try:
@@ -124,7 +138,7 @@ class helper:
 					'convert',
 					filename + '[0]',
 					'-resize',
-					resizeString % (displayWidth, displayHeight),
+					'%sx%s' % (adjWidth, adjHeight),
 					'-gravity',
 					'center',
 					'-crop',

--- a/services/svc_googlephotos.py
+++ b/services/svc_googlephotos.py
@@ -207,16 +207,21 @@ class GooglePhotos(BaseService):
       # Make sure we don't get a video, unsupported for now (gif is usually bad too)
       if entry['mimeType'] in types:
         # Calculate the size we need to avoid black borders
-        ow = float(entry['mediaMetadata']['width'])
-        oh = float(entry['mediaMetadata']['height'])
-        ar = ow/oh
+        ow = entry['mediaMetadata']['width']
+        oh = entry['mediaMetadata']['height']
+        oar=float(ow)/float(oh)
+        dar = float(displaySize['width'])/float(displaySize['height'])
 
-        if ow > displaySize['width']:
-          width = displaySize['width']
-          height = int(float(displaySize['width']) / ar)
+        if ow > displaySize['width'] and oh > displaySize['height']:
+          if oar <= dar:
+            width = displaySize['width']
+            height = int(float(displaySize['width']) / oar)
+          else:
+            width = int(float(displaySize['height']) * oar)
+            height = displaySize['height']
         else:
-          width = int(float(displaySize['height']) * ar)
-          height = displaySize['height']
+          width = ow
+          height = oh
 
         return entry['mimeType'], entry['baseUrl'] + "=w" + str(width) + "-h" + str(height), entry['productUrl']
       else:


### PR DESCRIPTION
Hi Henric, 

First of all thank you very much for making this amazing open-source project + great documentation!
I am currently building two wooden/digital picture frames of my own, so I'd love to contribute :)

I believe that there are some minor image scaling bugs within your code, so I tried to fix it (**svc_googlephotos.py**).
For instance, a lot of images are being pulled from the google-server with a small resolution and need to be upscaled afterwards when displaying them in ‘zoomOnly’-mode which will introduce artefacts. (look at your debug resizing messages)

Furthermore ‘zoomOnly’-mode doesn't always seem to work (**helper.py**).
An Image with a really small black border doesn't get zoomed at all.
I believe 
`if padding < 20 and not autoChoose:`
should have been 
`if padding < 20 and not autoChoose and not zoomOnly:`

But instead I differentiate the entire adjWidth/adjHeight block, because 'zoomOnly' images should be scaled differently than 'blurred' images!

I hope this explanation is somewhat comprehensible. 
Here is an album of images with unusual resolutions for testing purposes: 
https://photos.app.goo.gl/8PDq5eWQMYL2fdjVA

If you have any other questions or if my fixes broke something else, please let me know!

Leo
