### PR TITLE
 Only show images that match display orientation

### DIFF
--- a/modules/settings.py
+++ b/modules/settings.py
@@ -70,6 +70,7 @@ class settings:
       'display-driver' : 'none',
       'display-special' : None,
       'imagesizing' : 'blur',
+      'force_orientation' : 0
     }
 
   def load(self):

--- a/modules/slideshow.py
+++ b/modules/slideshow.py
@@ -117,7 +117,7 @@ class slideshow:
         svc = services[useService]['id']
 
         filename = os.path.join(self.settings.get('tempfolder'), 'image')
-        result = self.services.servicePrepareNextItem(svc, filename, supportedFormats, {'width' : self.settings.getUser('width'), 'height' : self.settings.getUser('height')})
+        result = self.services.servicePrepareNextItem(svc, filename, supportedFormats, {'width': self.settings.getUser('width'), 'height': self.settings.getUser('height'), 'force_orientation': self.settings.getUser('force_orientation')})
         if result['error'] is not None:
           self.display.message('%s failed:\n\n%s' % (services[useService]['name'], result['error']))
         else:

--- a/services/base.py
+++ b/services/base.py
@@ -409,7 +409,7 @@ class BaseService:
       return True
 
     # NOTE: square images are being treated as portrait-orientation
-    image_orientation = 0 if metadata["width"] > metadata["height"] else 1
+    image_orientation = 0 if int(metadata["width"]) > int(metadata["height"]) else 1
     display_orientation = 0 if displaySize["width"] > displaySize["height"] else 1
 
     return image_orientation == display_orientation

--- a/services/base.py
+++ b/services/base.py
@@ -404,4 +404,14 @@ class BaseService:
       os.unlink(n)
     self._MEMORY = []
 
+  def isCorrectOrientation(self, metadata, displaySize):
+    if displaySize['force_orientation'] == 0:
+      return True
+
+    # NOTE: square images are being treated as portrait-orientation
+    image_orientation = 0 if metadata["width"] > metadata["height"] else 1
+    display_orientation = 0 if displaySize["width"] > displaySize["height"] else 1
+
+    return image_orientation == display_orientation
+
 

--- a/services/svc_googlephotos.py
+++ b/services/svc_googlephotos.py
@@ -201,10 +201,11 @@ class GooglePhotos(BaseService):
       proposed = images[index]['baseUrl']
       if self.memorySeen(proposed):
         continue
+      self.memoryRemember(proposed)
+      
       if not self.isCorrectOrientation(images[index]['mediaMetadata'], displaySize):
         logging.debug("Skipping image '%s' due to wrong orientation!" % images[index]['filename'])
         continue
-      self.memoryRemember(proposed)
 
       entry = images[index]
       # Make sure we don't get a video, unsupported for now (gif is usually bad too)

--- a/services/svc_googlephotos.py
+++ b/services/svc_googlephotos.py
@@ -201,6 +201,9 @@ class GooglePhotos(BaseService):
       proposed = images[index]['baseUrl']
       if self.memorySeen(proposed):
         continue
+      if not self.isCorrectOrientation(images[index]['mediaMetadata'], displaySize):
+        logging.debug("Skipping image '%s' due to wrong orientation!" % images[index]['filename'])
+        continue
       self.memoryRemember(proposed)
 
       entry = images[index]

--- a/services/svc_picasaweb.py
+++ b/services/svc_picasaweb.py
@@ -105,10 +105,11 @@ class PicasaWeb(BaseService):
       proposed = images['feed']['entry'][index]['content']['src']
       if self.memorySeen(proposed):
         continue
+      self.memoryRemember(proposed)
+
       if not self.isCorrectOrientation(images[index]['mediaMetadata'], displaySize):
         logging.debug("Skipping image '%s' due to wrong orientation!" % images[index]['filename'])
         continue
-      self.memoryRemember(proposed)
 
       entry = images['feed']['entry'][index]
       # Make sure we don't get a video, unsupported for now (gif is usually bad too)

--- a/services/svc_picasaweb.py
+++ b/services/svc_picasaweb.py
@@ -105,6 +105,9 @@ class PicasaWeb(BaseService):
       proposed = images['feed']['entry'][index]['content']['src']
       if self.memorySeen(proposed):
         continue
+      if not self.isCorrectOrientation(images[index]['mediaMetadata'], displaySize):
+        logging.debug("Skipping image '%s' due to wrong orientation!" % images[index]['filename'])
+        continue
       self.memoryRemember(proposed)
 
       entry = images['feed']['entry'][index]

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -104,6 +104,15 @@ $("select[name=display-rotation]").change(function() {
   });
 });
 
+$("select[name=force_orientation]").change(function () {
+  var value = $(this).val()
+  $.ajax({
+    url: "/setting/" + $(this).attr('name') + "/" + encodeURIComponent($(this).val()),
+    type: "PUT"
+  }).done(function (){
+  });
+});
+
 $("select[name=imagesizing]").change(function() {
   $.ajax({
     url:"/setting/" + $(this).attr('name') + "/" + encodeURIComponent($(this).val()),

--- a/static/template/main.html
+++ b/static/template/main.html
@@ -36,8 +36,16 @@
       <option value="90">90 degrees clockwise</option>
       <option value="180">Up-side-down</option>
       <option value="270">90 degrees counter-clockwise</option>
-      {{/select}}
-    </select>
+	  {{/select}}
+	</select>
+	<br>
+	Only show images that match display orientation
+	<select name="force_orientation">
+		{{#select settings.force_orientation}}
+		<option value="0">no</option>
+		<option value="1">yes</option>
+		{{/select}}
+	</select>
 		<hr>
 		GPIO PIN to monitor for shutdown interrupts
 		<input value="{{settings.shutdown-pin}}" type="text" class="small" name="shutdown-pin" data-validate="gpio" data-confirm="gpio">


### PR DESCRIPTION
As I said, I am building two frames. They are supposed to work as an ensemble. One in portrait and the other one in landscape orientation. So here is new feature suggestion: 
You can force each picture frame to only show images matching its orientation. That way, portrait images don't show ugly big black borders - or don't need to be cropped as much - in landscape-oriented frames or vice versa. 
You can control this feature via the web interface (under the newly implemented rotation-setting)

Cheers
Leo