### PR TITLE
Rotate images using exif data

### DIFF
--- a/modules/helper.py
+++ b/modules/helper.py
@@ -47,6 +47,11 @@ class helper:
 			x -= normWeights[i]
 			if x <= 0.:
 				return i
+	@staticmethod
+    	def autoOrient(filename):
+            if not os.path.isfile(filename):
+                return False
+        return subprocess.call(['/usr/bin/mogrify', '-auto-orient', filename])
 
 	@staticmethod
 	def getResolution():

--- a/modules/slideshow.py
+++ b/modules/slideshow.py
@@ -206,6 +206,7 @@ class slideshow:
     return filenameProcessed
 
   def process(self, filename):
+    helper.autoOrient(filename)
     imageSizing = self.settings.getUser('imagesizing')
     if imageSizing == None or imageSizing == "none":
       return self._colormatch(filename)


### PR DESCRIPTION
This PR adds a new method to the helper module that checks the EXIF data (if present) and rotates the picture accordingly.   It also calls this method from the slideshow module "process" method as a first step before it does other processing.   This update fixes a problem with pictures shown from the USB or SMB service that are typically iPhone photos.   This addresses issue #112 