### PR TITLE
Update svc_usb.py

### DIFF
--- a/services/svc_usb.py
+++ b/services/svc_usb.py
@@ -293,11 +293,11 @@ class USB_Photos(BaseService):
       return []
     images = []
     if keyword == "_PHOTOFRAME_":
-      files = self.getBaseDirImages()
+      files = filter(lambda x: not x.startswith("."), self.getBaseDirImages())
       images = self.getAlbumInfo(self.baseDir, files)
     else:
       if os.path.isdir(os.path.join(self.baseDir, keyword)):
-        files = os.listdir(os.path.join(self.baseDir, keyword))
+        files = filter(lambda x: not x.startswith("."), os.listdir(os.path.join(self.baseDir, keyword)))
         images = self.getAlbumInfo(os.path.join(self.baseDir, keyword), files)
       else:
         logging.warning("The album '%s' does not exist. Did you unplug the storage device associated with '%s'?!" % (os.path.join(self.baseDir, keyword), self.device))


### PR DESCRIPTION
Added filter to ignore linux/macos "dot" files.  The main reason to do this is to eliminate long logs of 
Command '['/usr/bin/identify', u'/mnt/usb1/photoframe/test/.DS_Store']' returned non-zero exit status 1