### PR TITLE
Update MIGRATION.md

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,9 @@
-sudo apt install apt-utils git fbset python3-requests python3-requests-oauthlib python3-flask python3-flask-httpauth imagemagick python3-smbus bc
+Manual steps to try this branch
 
-pip3 install requests requests-oauthlib flask flask-httpauth smbus
-pip3 install netifaces
+    sudo bash
+    cd
+    apt install apt-utils git fbset python3-pip python3-requests python3-requests-oauthlib python3-flask  imagemagick python3-smbus bc
+    
+    pip3 install requests requests-oauthlib flask flask-httpauth smbus
+    pip3 install netifaces
+    


### PR DESCRIPTION
I took the 2019-01-05 image, freshly installed and upgraded to a clean current version on RPi3B.  Then tried the instructions.   pip3 needed to be installed, and in this distro, python3-flask-httpauth was not a separate package.   I thought it might be missing and tried installing with pip3, but it claimed that it was already there from the dist-packages.    BTW, do you have a flag for the update script to select a branch, or just use git --branch ?